### PR TITLE
Add result collectors

### DIFF
--- a/api/src/main/java/api/model/Row.java
+++ b/api/src/main/java/api/model/Row.java
@@ -25,7 +25,7 @@ public class Row implements Comparable<Row>, Serializable {
             throw new RuntimeException("Cannot create empty row");
         }
         this.values = new ArrayList<>(Arrays.asList(values));
-        this.hashKey = HASH_FUNCTION.hashString(String.valueOf(this.values.get(0)), Charsets.UTF_8).asLong();
+        this.hashKey = hash(String.valueOf(this.values.get(0)));
     }
 
     public List<String> getValues() {
@@ -49,6 +49,10 @@ public class Row implements Comparable<Row>, Serializable {
 
     public long getHashKey() {
         return hashKey;
+    }
+
+    public static long hash(String toHash) {
+        return HASH_FUNCTION.hashString(toHash, Charsets.UTF_8).asLong();
     }
 
     @Override

--- a/store/src/main/java/store/actors/ClientEndpoint.java
+++ b/store/src/main/java/store/actors/ClientEndpoint.java
@@ -9,6 +9,7 @@ import api.commands.SelectAllCommand;
 import api.commands.SelectCommand;
 import api.messages.LamportId;
 import api.messages.QueryMetaInfo;
+import store.messages.SelectKeyMsg;
 import store.messages.query.CreateTableMsg;
 import store.messages.query.InsertMsg;
 import store.messages.query.SelectAllMsg;
@@ -54,6 +55,7 @@ public class ClientEndpoint extends AbstractDBActor {
             case SELECT:
                 SelectCommand selectCommand = (SelectCommand) request.getCommand();
                 selectFrom(selectCommand, request.getClientRequestId(), request.getLamportId());
+                break;
             default:
                 log.error("Invalid command: {}", request.getCommand().getCommandType());
                 break;
@@ -81,8 +83,7 @@ public class ClientEndpoint extends AbstractDBActor {
 
     private void selectFrom(SelectCommand command, String clientRequestId, LamportId lamportId) {
         QueryMetaInfo queryMetaInfo = QueryMetaInfo.newReadMeta(getSender(), clientRequestId, lamportId);
-        Predicate<Row> whereFn = (row) -> row.getKey().equals(command.getKey());
-        SelectWhereMsg msg = new SelectWhereMsg(command.getTableName(), whereFn, queryMetaInfo);
+        SelectKeyMsg msg = new SelectKeyMsg(command.getTableName(), command.getKey(), queryMetaInfo);
         quorumManager.tell(msg, getSelf());
     }
 }

--- a/store/src/main/java/store/actors/QuorumManager.java
+++ b/store/src/main/java/store/actors/QuorumManager.java
@@ -31,12 +31,10 @@ public class QuorumManager extends AbstractDBActor {
 
     private final String id = UUID.randomUUID().toString();
     private final ClusterMemberRegistry memberRegistry;
-    private final Map<LamportId, List<QueryResponseMsg>> quorumResponses;
     private LamportId lamportId = new LamportId(id);
 
     private QuorumManager() {
         memberRegistry = new ClusterMemberRegistry();
-        quorumResponses = new HashMap<>();
         getContext().actorOf(ClusterMemberListener.props(memberRegistry), ClusterMemberListener.ACTOR_NAME);
     }
 
@@ -47,115 +45,21 @@ public class QuorumManager extends AbstractDBActor {
     @Override
     public Receive createReceive() {
         return receiveBuilder()
-                .match(QueryResponseMsg.class, this::handleQuorumResponse)
                 .match(QueryMsg.class, this::handleQuorum)
+                .matchAny(x -> log.error("Unknown message: {}", x))
                 .build();
     }
 
-    private void handleQuorumResponse(QueryResponseMsg msg) {
-        LamportId lampId = msg.getLamportId();
-        List<QueryResponseMsg> responses = quorumResponses.get(lampId);
-
-        // We have dealt with the quorum, the response can be ignored
-        if (responses == null) return;
-
-        responses.add(msg);
-
-        int requiredQuorumSize = msg.getQueryMetaInfo().isWriteQuery() ? WRITE_QUORUM : READ_QUORUM;
-
-        // Haven't seen enough responses
-        if (responses.size() < requiredQuorumSize) return;
-
-        QueryResponseMsg quorumResponse = getQuorumResponse(responses);
-        msg.getRequester().tell(quorumResponse, ActorRef.noSender());
-
-        // Drop quorum responses, as we have seen enough and replied
-        quorumResponses.remove(lampId);
-    }
 
     private void handleQuorum(QueryMsg msg) {
         QueryMetaInfo meta = addNewLamportId(msg.getQueryMetaInfo());
         msg.updateMetaInfo(meta);
 
-        LamportId lampId = msg.getLamportId();
-        List<QueryResponseMsg> responses = quorumResponses.put(lampId, new ArrayList<>());
+        int quorumSize = msg.getQueryMetaInfo().isWriteQuery() ? WRITE_QUORUM : READ_QUORUM;
+        ActorRef quorumCollector = getContext().actorOf(QuorumResponseCollector.props(msg.getRequester(), quorumSize));
 
-        if (responses != null) {
-            // We have seen this queryMetaInfo before and can ignore it
-            quorumResponses.put(lampId, responses);
-            return;
-        }
         memberRegistry.getMasters()
-                .forEach(actorPath -> getContext().actorSelection(actorPath).tell(msg, getSelf()));
-    }
-
-    private QueryResponseMsg getQuorumResponse(List<QueryResponseMsg> messages) {
-        QueryMetaInfo queryMetaInfo = messages.get(0).getQueryMetaInfo();
-        LamportId lampId = queryMetaInfo.getLamportId();
-        log.debug("({}) Quorum response", lampId);
-
-        // TODO: ugly code
-        Class<? extends QueryResponseMsg> msgClass = messages.get(0).getClass();
-        boolean allResponsesSameType = true;
-        QueryErrorMsg encounteredError = null;
-
-        for (QueryResponseMsg msg : messages) {
-            allResponsesSameType &= msg.getClass() == msgClass;
-            if (msg.getClass() == QueryErrorMsg.class) {
-                encounteredError = (QueryErrorMsg) msg;
-            }
-        }
-
-        if (!allResponsesSameType) {
-            // If we have different types and no error, something is really wrong
-            assert encounteredError != null;
-
-            // We encountered an error, because they are not all errors and at least one is not of typ Success/Result
-            return new QueryErrorMsg("At least one node returned an error response: " + encounteredError.getMsg(),
-                    queryMetaInfo);
-        }
-
-        if (msgClass == PartialQueryResultMsg.class) {
-            return getResultQuorum(messages);
-        } else if (msgClass == QuerySuccessMsg.class) {
-            return getSuccessQuorum(messages);
-        } else if (msgClass == QueryErrorMsg.class) {
-            return getErrorQuorum(messages);
-        } else {
-            throw new RuntimeException("Unknown queryMetaInfo response");
-        }
-    }
-
-    private QueryResponseMsg getResultQuorum(List<QueryResponseMsg> messages) {
-        Map<Long, StoredRow> resultRowsMap = new HashMap<>();
-
-        for (QueryResponseMsg msg : messages) {
-            PartialQueryResultMsg resultMsg = (PartialQueryResultMsg) msg;
-            for (StoredRow storedRow : resultMsg.getResult()) {
-                long key = storedRow.getRow().getHashKey();
-                StoredRow prev = resultRowsMap.get(key);
-
-                // If a newer version is in the result set, ignore this row
-                if (prev != null && prev.getLamportId().isGreaterThan(storedRow.getLamportId())) {
-                    continue;
-                }
-
-                resultRowsMap.put(key, storedRow);
-            }
-        }
-
-        List<Row> resultRows = resultRowsMap.values().stream().map(StoredRow::getRow).collect(Collectors.toList());
-        return new QueryResultMsg(resultRows, messages.get(0).getQueryMetaInfo());
-    }
-
-    private QueryResponseMsg getSuccessQuorum(List<QueryResponseMsg> messages) {
-        // All queries returned success, so we can return any one of them
-        return messages.get(0);
-    }
-
-    private QueryResponseMsg getErrorQuorum(List<QueryResponseMsg> messages) {
-        // All queries returned an error, so we can return any one of them
-        return messages.get(0);
+                .forEach(actorPath -> getContext().actorSelection(actorPath).tell(msg, quorumCollector));
     }
 
     private QueryMetaInfo addNewLamportId(QueryMetaInfo queryMetaInfo) {

--- a/store/src/main/java/store/actors/QuorumResponseCollector.java
+++ b/store/src/main/java/store/actors/QuorumResponseCollector.java
@@ -1,0 +1,109 @@
+package store.actors;
+
+import akka.actor.ActorRef;
+import akka.actor.Props;
+import api.messages.LamportId;
+import api.messages.QueryErrorMsg;
+import api.messages.QueryMetaInfo;
+import api.messages.QueryResponseMsg;
+import api.messages.QueryResultMsg;
+import api.messages.QuerySuccessMsg;
+import api.model.Row;
+import store.messages.query.PartialQueryResultMsg;
+import store.model.StoredRow;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class QuorumResponseCollector extends AbstractDBActor {
+
+    private final ActorRef client;
+    private final int quorumSize;
+
+    private final List<QueryResponseMsg> quorumResponses;
+
+    public QuorumResponseCollector(ActorRef client, int quorumSize) {
+        this.client = client;
+        this.quorumSize = quorumSize;
+
+        quorumResponses = new ArrayList<>();
+    }
+
+    static Props props(ActorRef client, int quorumSize) {
+        return Props.create(QuorumResponseCollector.class, () -> new QuorumResponseCollector(client, quorumSize));
+    }
+
+    @Override
+    public Receive createReceive() {
+        return receiveBuilder()
+                .match(QueryResponseMsg.class, this::handleQueryResponseMsg)
+                .matchAny(x -> log.error("Unknown message: {}", x))
+                .build();
+    }
+
+    private void handleQueryResponseMsg(QueryResponseMsg msg) {
+        // For now, if we see an error we assume everything is an error
+        if (msg instanceof QueryErrorMsg) {
+            client.tell(msg, ActorRef.noSender());
+            getContext().stop(getSelf());
+            return;
+        }
+
+        quorumResponses.add(msg);
+
+        if (quorumResponses.size() < quorumSize) return;
+
+        // Seen all results, pass result to quorumManager
+        QueryResponseMsg quorumResponse = getQuorumResponse();
+        client.tell(quorumResponse, ActorRef.noSender());
+
+        // The collector has finished its job so it can be destroyed
+        getContext().stop(getSelf());
+    }
+
+    private QueryResponseMsg getQuorumResponse() {
+        QueryMetaInfo queryMetaInfo = quorumResponses.get(0).getQueryMetaInfo();
+        LamportId lampId = queryMetaInfo.getLamportId();
+        log.debug("({}) Quorum response", lampId);
+
+        Class<? extends QueryResponseMsg> msgClass = quorumResponses.get(0).getClass();
+
+        if (msgClass == PartialQueryResultMsg.class) {
+            return getResultQuorum();
+        } else if (msgClass == QuerySuccessMsg.class) {
+            return getSuccessQuorum();
+        } else {
+            throw new RuntimeException("Unknown response type: " + msgClass);
+        }
+    }
+
+    private QueryResponseMsg getResultQuorum() {
+        Map<Long, StoredRow> resultRowsMap = new HashMap<>();
+
+        for (QueryResponseMsg msg : quorumResponses) {
+            PartialQueryResultMsg resultMsg = (PartialQueryResultMsg) msg;
+            for (StoredRow storedRow : resultMsg.getResult()) {
+                long key = storedRow.getRow().getHashKey();
+                StoredRow prev = resultRowsMap.get(key);
+
+                // If a newer version is in the result set, ignore this row
+                if (prev != null && prev.getLamportId().isGreaterThan(storedRow.getLamportId())) {
+                    continue;
+                }
+
+                resultRowsMap.put(key, storedRow);
+            }
+        }
+
+        List<Row> resultRows = resultRowsMap.values().stream().map(StoredRow::getRow).collect(Collectors.toList());
+        return new QueryResultMsg(resultRows, quorumResponses.get(0).getQueryMetaInfo());
+    }
+
+    private QueryResponseMsg getSuccessQuorum() {
+        // All queries returned success, so we can return any one of them
+        return quorumResponses.get(0);
+    }
+}

--- a/store/src/main/java/store/actors/Table.java
+++ b/store/src/main/java/store/actors/Table.java
@@ -2,31 +2,28 @@ package store.actors;
 
 import akka.actor.ActorRef;
 import akka.actor.Props;
-import api.messages.LamportId;
+import api.messages.QueryErrorMsg;
+import api.messages.QuerySuccessMsg;
+import api.model.Row;
+import com.google.common.base.Charsets;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.MultimapBuilder;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeMap;
 import com.google.common.collect.TreeRangeMap;
+import store.messages.SelectKeyMsg;
 import store.messages.partition.PartitionBlockedMsg;
 import store.messages.partition.PartitionFullMsg;
 import store.messages.partition.SplitPartitionMsg;
 import store.messages.partition.SplitSuccessMsg;
 import store.messages.query.InsertRowMsg;
-import store.messages.query.PartialQueryResultMsg;
-import api.messages.QueryErrorMsg;
-import api.messages.QuerySuccessMsg;
 import store.messages.query.SelectAllMsg;
 import store.messages.query.SelectWhereMsg;
 import store.model.BlockedRow;
-import store.model.StoredRow;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 public class Table extends AbstractDBActor {
@@ -35,25 +32,13 @@ public class Table extends AbstractDBActor {
     // Map of Rows that could not be inserted to a partition because of ongoing splitting
     private final Multimap<ActorRef, BlockedRow> blockedRows;
 
-    // Maps of current transactions (by ID) to the actors which have not responded and to the accumulated result
-    private final Map<LamportId, Set<ActorRef>> runningQueries;
-    private final Multimap<LamportId, StoredRow> runningQueryResults;
-    private final Map<LamportId, ActorRef> queryQuorumManagers;
-
     // Map of all leading partitions and the key ranges they each cover
     private final RangeMap<Long, ActorRef> partitions = TreeRangeMap.create();
-
-
-    // Counter to give unique ids to each partition
-    private int highestPartitionId = 1;
 
     private Table(List<String> layout) {
         this.layout = layout;
 
         blockedRows = MultimapBuilder.hashKeys().arrayListValues().build();
-        runningQueries = new HashMap<>();
-        runningQueryResults = MultimapBuilder.hashKeys().arrayListValues().build();
-        queryQuorumManagers = new HashMap<>();
 
         Range<Long> startRange = Range.closed(Long.MIN_VALUE, Long.MAX_VALUE);
         createPartition(startRange);
@@ -69,11 +54,11 @@ public class Table extends AbstractDBActor {
                 // Querying
                 .match(SelectAllMsg.class, this::handleSelectAll)
                 .match(SelectWhereMsg.class, this::handleSelectWhere)
+                .match(SelectKeyMsg.class, this::handleSelectKey)
                 .match(InsertRowMsg.class, this::handleInsert)
                 .match(QuerySuccessMsg.class, this::handleQuerySuccess)
 
                 // Partitioning
-                .match(PartialQueryResultMsg.class, this::handlePartialQueryResult)
                 .match(PartitionFullMsg.class, this::handlePartitionFull)
                 .match(PartitionBlockedMsg.class, this::handlePartitionBlocked)
                 .match(SplitSuccessMsg.class, this::handleSplitSuccess)
@@ -83,13 +68,19 @@ public class Table extends AbstractDBActor {
     }
 
     private void handleSelectAll(SelectAllMsg msg) {
-        startTransaction(msg.getLamportId());
-        broadcastToPartitions(msg);
+        ActorRef resultCollector = startMultiPartitionQuery();
+        broadcastToPartitions(msg, resultCollector);
     }
 
     private void handleSelectWhere(SelectWhereMsg msg) {
-        startTransaction(msg.getLamportId());
-        broadcastToPartitions(msg);
+        ActorRef resultCollector = startMultiPartitionQuery();
+        broadcastToPartitions(msg, resultCollector);
+    }
+
+    private void handleSelectKey(SelectKeyMsg msg) {
+        long hashKey = Row.hash(msg.getKey());
+        ActorRef partition = partitions.get(hashKey);
+        partition.tell(msg, getSender());
     }
 
     private void handleInsert(InsertRowMsg msg) {
@@ -99,21 +90,6 @@ public class Table extends AbstractDBActor {
         }
         ActorRef partition = partitions.get(msg.getRow().getHashKey());
         partition.tell(msg, getSender());
-    }
-
-    private void handlePartialQueryResult(PartialQueryResultMsg msg) {
-        LamportId lamportId = msg.getLamportId();
-
-        runningQueryResults.putAll(lamportId, msg.getResult());
-        updateTransaction(lamportId, getSender());
-
-        if (!isTransactionDone(lamportId)) return;
-
-        List<StoredRow> result = new ArrayList<>(runningQueryResults.get(lamportId));
-        ActorRef quorumManager = queryQuorumManagers.get(lamportId);
-        log.debug("Telling QM: {}", lamportId);
-        quorumManager.tell(new PartialQueryResultMsg(result, msg.getQueryMetaInfo()), getSelf());
-        finishTransaction(lamportId);
     }
 
     private void handlePartitionFull(PartitionFullMsg msg) {
@@ -145,47 +121,26 @@ public class Table extends AbstractDBActor {
         msg.getRequester().tell(msg, getSelf());
     }
 
-    private void startTransaction(LamportId lamportId) {
-        runningQueries.put(lamportId, createCurrentPartitionSet());
-        queryQuorumManagers.put(lamportId, getSender());
+    private ActorRef startMultiPartitionQuery() {
+        return getContext().actorOf(TableResponseCollector.props(getSender(), createCurrentPartitionSet()));
     }
 
-    private void updateTransaction(LamportId lamportId, ActorRef actor) {
-        Set<ActorRef> partitionSet = runningQueries.get(lamportId);
-        if (partitionSet == null) {
-            log.error("Cannot update queryMetaInfo #{}. It is not present in list of transactions", lamportId);
-            return;
-        }
-        partitionSet.remove(actor);
-    }
-
-    private boolean isTransactionDone(LamportId lamportId) {
-        Set<ActorRef> partitionSet = runningQueries.get(lamportId);
-        return partitionSet != null && partitionSet.isEmpty();
-    }
-
-    private void finishTransaction(LamportId lamportId) {
-        runningQueries.remove(lamportId);
-        runningQueryResults.removeAll(lamportId);
-        queryQuorumManagers.remove(lamportId);
+    private ActorRef startSinglePartitionQuery(ActorRef partition) {
+        Set<ActorRef> partitionSet = new HashSet<>();
+        partitionSet.add(partition);
+        return getContext().actorOf(TableResponseCollector.props(getSender(), partitionSet));
     }
 
     private ActorRef createPartition(Range<Long> range) {
-        int partitionId = getNextPartitionId();
-        log.debug("Created new leader partition #{} with range: {}", partitionId, range);
-        ActorRef partition = getContext().actorOf(Partition.props(partitionId, range, getSelf()), "partition-" +
-                partitionId);
+        log.debug("Created new leader partition with range: {}", range);
+        ActorRef partition = getContext().actorOf(Partition.props(range, getSelf()));
 
         partitions.put(range, partition);
         return partition;
     }
 
-    private int getNextPartitionId() {
-        return highestPartitionId++;
-    }
-
-    private <MsgType> void broadcastToPartitions(MsgType msg) {
-        partitions.asMapOfRanges().forEach((range, partition) -> partition.tell(msg, getSelf()));
+    private <MsgType> void broadcastToPartitions(MsgType msg, ActorRef resultCollector) {
+        partitions.asMapOfRanges().forEach((range, partition) -> partition.tell(msg, resultCollector));
     }
 
     private Set<ActorRef> createCurrentPartitionSet() {

--- a/store/src/main/java/store/actors/TableResponseCollector.java
+++ b/store/src/main/java/store/actors/TableResponseCollector.java
@@ -1,0 +1,51 @@
+package store.actors;
+
+import akka.actor.ActorRef;
+import akka.actor.Props;
+import store.messages.query.PartialQueryResultMsg;
+import store.model.StoredRow;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public class TableResponseCollector extends AbstractDBActor {
+
+    private final ActorRef quorumManager;
+    private final Set<ActorRef> queriedPartitions;
+
+    private final List<StoredRow> runningQueryResults;
+
+    private TableResponseCollector(ActorRef quorumManager, Set<ActorRef> queriedPartitions) {
+        this.quorumManager = quorumManager;
+        this.queriedPartitions = queriedPartitions;
+
+        runningQueryResults = new ArrayList<>();
+    }
+
+    static Props props(ActorRef quorumManager, Set<ActorRef> queriedPartitions) {
+        return Props.create(TableResponseCollector.class, () -> new TableResponseCollector(quorumManager, queriedPartitions));
+    }
+
+    @Override
+    public Receive createReceive() {
+        return receiveBuilder()
+                .match(PartialQueryResultMsg.class, this::handlePartialQueryResult)
+                .matchAny(x -> log.error("Unknown message: {}", x))
+                .build();
+    }
+
+    private void handlePartialQueryResult(PartialQueryResultMsg msg) {
+        runningQueryResults.addAll(msg.getResult());
+
+        queriedPartitions.remove(getSender());
+
+        if (!queriedPartitions.isEmpty()) return;
+
+        // Seen all results, pass result to quorumManager
+        quorumManager.tell(new PartialQueryResultMsg(runningQueryResults, msg.getQueryMetaInfo()), ActorRef.noSender());
+
+        // The collector has finished its job so it can be destroyed
+        getContext().stop(getSelf());
+    }
+}

--- a/store/src/main/java/store/messages/SelectKeyMsg.java
+++ b/store/src/main/java/store/messages/SelectKeyMsg.java
@@ -1,0 +1,27 @@
+package store.messages;
+
+import api.messages.QueryMetaInfo;
+import api.messages.QueryMsg;
+
+public class SelectKeyMsg extends QueryMsg {
+
+    private String tableName;
+    private String key;
+
+    // Used for serialization
+    private SelectKeyMsg() {}
+
+    public SelectKeyMsg(String tableName, String key, QueryMetaInfo queryMetaInfo) {
+        super(queryMetaInfo);
+        this.tableName = tableName;
+        this.key = key;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public String getKey() {
+        return key;
+    }
+}

--- a/store/src/test/java/WorkflowTests.java
+++ b/store/src/test/java/WorkflowTests.java
@@ -1,6 +1,7 @@
 import api.commands.CreateTableCommand;
 import api.commands.InsertIntoCommand;
 import api.commands.SelectAllCommand;
+import api.commands.SelectCommand;
 import api.configuration.EnvConfig;
 import client.DatastoreClient;
 import client.config.DatastoreClientModule;
@@ -137,6 +138,31 @@ public class WorkflowTests {
         for (int i = 0; i < rows.size(); i++) {
             assertThat(rows.get(i).getValues()).isEqualTo(values.get(i));
         }
+    }
+
+    @Test
+    public void givenSelectKeyCmdThenReceiveMatchedRow() throws Exception {
+        // GIVEN
+        List<List<String>> values = ImmutableList.of(
+                ImmutableList.of("1", "val1"),
+                ImmutableList.of("2", "val2"),
+                ImmutableList.of("3", "val3"));
+        createDefaultTable();
+        insertValues(DEFAULT_TABLE_NAME, values);
+
+        // WHEN
+        SelectCommand command = SelectCommand.builder()
+                .tableName(DEFAULT_TABLE_NAME)
+                .key("2")
+                .build();
+        CompletableFuture<QueryResponseMsg> response = client.sendRequest(command);
+
+        // THEN
+        assertThat(response.get()).isInstanceOf(QueryResultMsg.class);
+        QueryResultMsg queryResponse = (QueryResultMsg) response.get();
+        ImmutableList<Row> rows = sortRowsByKey(queryResponse.getResult());
+        assertThat(rows.size()).isEqualTo(1);
+        assertThat(rows.get(0).getValues()).isEqualTo(values.get(1));
     }
 
     @Test


### PR DESCRIPTION
Adds result collectors for multi-partition and multi-master queries. The QuorumManager and the able don't have to handle the responses directly and it makes the code a lot cleaner.