### PR TITLE
Allow remote host

### DIFF
--- a/api/src/main/java/api/configuration/EnvConfig.java
+++ b/api/src/main/java/api/configuration/EnvConfig.java
@@ -15,6 +15,10 @@ public class EnvConfig {
         return EnvConfig.builder().build();
     }
 
+    public static EnvConfig withIpAndPort(String ip, int port) {
+        return EnvConfig.builder().hostname(ip).port(port).build();
+    }
+
     public static EnvConfig withPort(int port) {
         return EnvConfig.builder().port(port).build();
     }

--- a/benchmark/src/main/java/ActorDbClient.java
+++ b/benchmark/src/main/java/ActorDbClient.java
@@ -34,9 +34,10 @@ public class ActorDbClient extends DB {
     public void init() throws DBException {
         Properties props = getProperties();
         int clientPort = Integer.valueOf(props.getProperty("clientPort"));
+        String storeIp = String.valueOf(props.getProperty("storeIp"));
         int storePort = Integer.valueOf(props.getProperty("storePort"));
         EnvConfig clientEnvConfig = EnvConfig.withPort(clientPort);
-        EnvConfig storeEnvConfig = EnvConfig.withPort(storePort);
+        EnvConfig storeEnvConfig = EnvConfig.withIpAndPort(storeIp, storePort);
         client = DatastoreClientModule.createInstance(clientEnvConfig, storeEnvConfig);
         client.start();
 


### PR DESCRIPTION
To use the Datastore from a remote host, you also need to change:

store/src/main/java/store/DatastoreMain.java:
`storeHost = <host-ip>`

store/src/main/resources/akka.conf:
`seed-nodes = ["akka.tcp://actors-db@<host-ip>:2552"]`