### PR TITLE
Move configurables to DatastoreConfig; Add config loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Custom config overrides
+datastore.properties
+
 # Gradle
 .gradle
 gradlew.bat
@@ -11,6 +14,7 @@ out
 
 # Native files
 native
+bin
 
 # Idea files
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ out
 # Log files
 *.log
 
+# Native files
+native
+
 # Idea files
 .idea
 *.iml

--- a/api/src/main/java/api/configuration/AkkaConfigLoader.java
+++ b/api/src/main/java/api/configuration/AkkaConfigLoader.java
@@ -8,11 +8,13 @@ public class AkkaConfigLoader {
 
     private static final String AKKA_HOSTNAME_FIELD = "akka.remote.netty.tcp.hostname";
     private static final String AKKA_PORT_FIELD = "akka.remote.netty.tcp.port";
+    private static final String AKKA_SEED_FIELD = "akka.cluster.seed-nodes";
 
-    public static Config loadAkkaConfig(String conifgPath, EnvConfig envConfig) {
-        return ConfigFactory.load(conifgPath)
+    public static Config loadAkkaConfig(String configPart, EnvConfig envConfig) {
+        return ConfigFactory.load(configPart)
                 .withValue(AKKA_HOSTNAME_FIELD, ConfigValueFactory.fromAnyRef(envConfig.getHostname()))
-                .withValue(AKKA_PORT_FIELD, ConfigValueFactory.fromAnyRef(envConfig.getPort()));
+                .withValue(AKKA_PORT_FIELD, ConfigValueFactory.fromAnyRef(envConfig.getPort()))
+                .withValue(AKKA_SEED_FIELD, ConfigValueFactory.fromAnyRef(envConfig.getSeedNodes()));
     }
 
     private AkkaConfigLoader() {}

--- a/api/src/main/java/api/configuration/EnvConfig.java
+++ b/api/src/main/java/api/configuration/EnvConfig.java
@@ -26,6 +26,8 @@ public class EnvConfig {
     private int writeQuorum = 1;
     @Builder.Default
     private int partitionCapacity = 100;
+    @Builder.Default
+    private boolean isBenchmarkTable = false;
 
     public static EnvConfig withDefaults() {
         return EnvConfig.builder().build();

--- a/api/src/main/java/api/configuration/EnvConfig.java
+++ b/api/src/main/java/api/configuration/EnvConfig.java
@@ -1,7 +1,13 @@
 package api.configuration;
 
+import com.google.common.collect.ImmutableList;
 import lombok.Builder;
 import lombok.Data;
+
+import java.util.List;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.String.format;
 
 @Data
 @Builder
@@ -10,6 +16,16 @@ public class EnvConfig {
     private final String hostname = "127.0.0.1";
     @Builder.Default
     private final int port = 2552;
+    @Builder.Default
+    private final String propertiesLocation = "datastore";
+    @Builder.Default
+    private final List<String> seedNodes = ImmutableList.of("127.0.0.1:2552");
+    @Builder.Default
+    private final int readQuorum = 1;
+    @Builder.Default
+    private int writeQuorum = 1;
+    @Builder.Default
+    private int partitionCapacity = 100;
 
     public static EnvConfig withDefaults() {
         return EnvConfig.builder().build();
@@ -21,5 +37,11 @@ public class EnvConfig {
 
     public static EnvConfig withPort(int port) {
         return EnvConfig.builder().port(port).build();
+    }
+
+    public ImmutableList<String> getSeedNodes() {
+        return seedNodes.stream()
+                .map(address -> format("akka.tcp://actor-db@%s", address))
+                .collect(toImmutableList());
     }
 }

--- a/store/src/main/java/store/DatastoreMain.java
+++ b/store/src/main/java/store/DatastoreMain.java
@@ -25,6 +25,7 @@ public class DatastoreMain {
                 .readQuorum(arguments.getReadQuorum())
                 .writeQuorum(arguments.getWriteQuorum())
                 .partitionCapacity(arguments.getPartitionCapacity())
+                .isBenchmarkTable(arguments.isBenchmark())
                 .build();
 
         new DatastoreMain().run(storeEnvConfig);
@@ -48,6 +49,8 @@ public class DatastoreMain {
         @Parameter(names = {"--writeQuorum", "-w"}, description = "Write quorum count")
         private int writeQuorum = 1;
         @Parameter(names = {"--partitionCapacity", "-c"}, description = "Max partition capacity")
-        private int partitionCapacity = 1;
+        private int partitionCapacity = 100;
+        @Parameter(names = {"--benchmark", "-b"}, description = "Create benchmark table")
+        private boolean isBenchmark  = false;
     }
 }

--- a/store/src/main/java/store/DatastoreMain.java
+++ b/store/src/main/java/store/DatastoreMain.java
@@ -3,8 +3,12 @@ package store;
 import api.configuration.EnvConfig;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
+import com.google.common.collect.ImmutableList;
 import lombok.Data;
 import store.configuration.DatastoreModule;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class DatastoreMain {
 
@@ -17,6 +21,10 @@ public class DatastoreMain {
         EnvConfig storeEnvConfig = EnvConfig.builder()
                 .hostname(arguments.getStoreHost())
                 .port(arguments.getStorePort())
+                .seedNodes(arguments.getSeedNodes())
+                .readQuorum(arguments.getReadQuorum())
+                .writeQuorum(arguments.getWriteQuorum())
+                .partitionCapacity(arguments.getPartitionCapacity())
                 .build();
 
         new DatastoreMain().run(storeEnvConfig);
@@ -29,9 +37,17 @@ public class DatastoreMain {
 
     @Data
     public static class StoreArgs {
-        @Parameter(names = "--storeHost", description = "Host address of the store")
+        @Parameter(names = {"--storeHost", "-h"}, description = "Host address of the store")
         private String storeHost = "127.0.0.1";
-        @Parameter(names = "--storePort", description = "Port of the store")
+        @Parameter(names = {"--storePort", "-p"}, description = "Port of the store")
         private int storePort = 2552;
+        @Parameter(names = {"--seedNode", "-s"}, description = "Seed node address")
+        private List<String> seedNodes = ImmutableList.of("127.0.0.1:2552");
+        @Parameter(names = {"--readQuorum", "-r"}, description = "Read quorum count")
+        private int readQuorum = 1;
+        @Parameter(names = {"--writeQuorum", "-w"}, description = "Write quorum count")
+        private int writeQuorum = 1;
+        @Parameter(names = {"--partitionCapacity", "-c"}, description = "Max partition capacity")
+        private int partitionCapacity = 1;
     }
 }

--- a/store/src/main/java/store/actors/Partition.java
+++ b/store/src/main/java/store/actors/Partition.java
@@ -46,7 +46,7 @@ public class Partition extends AbstractDBActor {
 
     private Partition(Range<Long> startRange, ActorRef table) {
         DatastoreConfig config = DatastoreModule.inject(DatastoreConfig.class);
-        this.capacity = config.getPartitionCapacity();
+        this.capacity = config.getEnvConfig().getPartitionCapacity();
         this.range = startRange;
         this.table = table;
         this.rows = new HashMap<>(capacity);

--- a/store/src/main/java/store/actors/QuorumManager.java
+++ b/store/src/main/java/store/actors/QuorumManager.java
@@ -44,7 +44,7 @@ public class QuorumManager extends AbstractDBActor {
         QueryMetaInfo meta = addNewLamportId(msg.getQueryMetaInfo());
         msg.updateMetaInfo(meta);
 
-        int quorumSize = msg.getQueryMetaInfo().isWriteQuery() ? config.getWriteQuorum() : config.getReadQuorum();
+        int quorumSize = msg.getQueryMetaInfo().isWriteQuery() ? config.getEnvConfig().getWriteQuorum() : config.getEnvConfig().getReadQuorum();
         ActorRef quorumCollector = getContext().actorOf(QuorumResponseCollector.props(msg.getRequester(), quorumSize));
 
         memberRegistry.getMasters()

--- a/store/src/main/java/store/configuration/DatastoreConfig.java
+++ b/store/src/main/java/store/configuration/DatastoreConfig.java
@@ -2,23 +2,16 @@ package store.configuration;
 
 import api.configuration.EnvConfig;
 import com.typesafe.config.Config;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
+import lombok.Setter;
 
 @Data
 @Builder
+@Setter(AccessLevel.NONE)
 public class DatastoreConfig {
     // Environment configs
     private final EnvConfig envConfig;
     private final Config akkaConfig;
-
-    // Quorum configs
-    @Builder.Default
-    private final int readQuorum = 1;
-    @Builder.Default
-    private final int writeQuorum = 1;
-
-    // Partition configs
-    @Builder.Default
-    private final int partitionCapacity = 100;
 }

--- a/store/src/main/java/store/configuration/DatastoreConfig.java
+++ b/store/src/main/java/store/configuration/DatastoreConfig.java
@@ -8,6 +8,17 @@ import lombok.Data;
 @Data
 @Builder
 public class DatastoreConfig {
+    // Environment configs
     private final EnvConfig envConfig;
     private final Config akkaConfig;
+
+    // Quorum configs
+    @Builder.Default
+    private final int readQuorum = 1;
+    @Builder.Default
+    private final int writeQuorum = 1;
+
+    // Partition configs
+    @Builder.Default
+    private final int partitionCapacity = 100;
 }

--- a/store/src/main/java/store/configuration/DatastoreModule.java
+++ b/store/src/main/java/store/configuration/DatastoreModule.java
@@ -9,6 +9,11 @@ import com.google.inject.Provides;
 import com.typesafe.config.Config;
 import store.Datastore;
 
+import java.util.MissingResourceException;
+import java.util.Optional;
+import java.util.PropertyResourceBundle;
+import java.util.ResourceBundle;
+
 public class DatastoreModule extends AbstractModule {
 
     private static final String AKKA_REMOTE_CONFIG = "akka.conf";

--- a/store/src/main/java/store/configuration/DatastoreModule.java
+++ b/store/src/main/java/store/configuration/DatastoreModule.java
@@ -12,19 +12,25 @@ import store.Datastore;
 public class DatastoreModule extends AbstractModule {
 
     private static final String AKKA_REMOTE_CONFIG = "akka.conf";
+
+    private static Injector injector;
+
     private final EnvConfig envConfig;
 
     public DatastoreModule(EnvConfig envConfig) {
         this.envConfig = envConfig;
     }
 
-    public static Datastore createInstance() {
-        return DatastoreModule.createInstance(EnvConfig.withDefaults());
+    public static Datastore createInstance(EnvConfig envConfig) {
+        injector = Guice.createInjector(new DatastoreModule(envConfig));
+        return injector.getInstance(Datastore.class);
     }
 
-    public static Datastore createInstance(EnvConfig envConfig) {
-        Injector injector = Guice.createInjector(new DatastoreModule(envConfig));
-        return injector.getInstance(Datastore.class);
+    public static <T> T inject(Class<T> type) {
+        if (injector == null) {
+            throw new IllegalStateException("Injector not initialized");
+        }
+        return injector.getInstance(type);
     }
 
     @Override

--- a/store/src/main/java/store/messages/query/SelectWhereMsg.java
+++ b/store/src/main/java/store/messages/query/SelectWhereMsg.java
@@ -4,7 +4,6 @@ import api.messages.QueryMetaInfo;
 import api.messages.QueryMsg;
 import api.model.Row;
 
-import java.lang.invoke.SerializedLambda;
 import java.util.function.Predicate;
 
 public class SelectWhereMsg extends QueryMsg {

--- a/store/src/main/resources/akka.conf
+++ b/store/src/main/resources/akka.conf
@@ -33,7 +33,8 @@ akka {
   }
 
   cluster {
-    seed-nodes = ["akka.tcp://actor-db@127.0.0.1:2552"]
+    // Set programatically
+    // seed-nodes = ["akka.tcp://actor-db@127.0.0.1:2552"]
     // For local testing
     jmx.multi-mbeans-in-same-jvm = on
 

--- a/store/src/main/resources/datastore.properties
+++ b/store/src/main/resources/datastore.properties
@@ -1,1 +1,0 @@
-readQuorum=2

--- a/store/src/main/resources/datastore.properties
+++ b/store/src/main/resources/datastore.properties
@@ -1,0 +1,1 @@
+readQuorum=2

--- a/store/src/test/java/MultiNodeTests.java
+++ b/store/src/test/java/MultiNodeTests.java
@@ -7,16 +7,13 @@ import api.messages.QuerySuccessMsg;
 import client.DatastoreClient;
 import client.config.DatastoreClientModule;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import store.Datastore;
 import store.configuration.DatastoreModule;
 
-import java.lang.reflect.Array;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;

--- a/store/src/test/java/WorkflowTests.java
+++ b/store/src/test/java/WorkflowTests.java
@@ -17,7 +17,6 @@ import org.junit.Before;
 import org.junit.Test;
 import store.Datastore;
 import store.configuration.DatastoreModule;
-import store.messages.query.SelectKeyMsg;
 
 import java.util.ArrayList;
 import java.util.Comparator;


### PR DESCRIPTION
* Moves all configurables to `DatastoreConfig` which actors can inject.
* Fields in `DatastoreConfig` annotated with `@PropertyFieldName` are overwritten with values in a given properties file (only if exists, defaults to `datastore.properties` as set in `EnvConfig`).

Closes https://github.com/fawind/actor-db/issues/3.